### PR TITLE
Display respective seller in order_list

### DIFF
--- a/eMarket/app/templates/app/admin_dashboard.html
+++ b/eMarket/app/templates/app/admin_dashboard.html
@@ -28,7 +28,7 @@
                 {{ order.user }} bought:
                     {% for product_id, product_details in order.cart_products.items %}
                     <li>
-                        {{ product_details.quantity }} {{ product_details.name }} from {{ order.user }} <br> 
+                        {{ product_details.quantity }} {{ product_details.name }} from {{ product_details.seller }} <br> 
                     </li> 
                     {% endfor %}
                 Status: {{order.status}} <br><br>


### PR DESCRIPTION
Small fix I forgot to commit in the other branch. The order list is supposed to show the seller as well as the buyer, so this grants that need.